### PR TITLE
Upgrade to Kafka 0.10.2.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,8 +18,8 @@ dependencies {
   compile gradleApi()
   compile localGroovy()
 
-  compile 'org.apache.kafka:kafka_2.11:0.8.2.0'
-  compile 'org.apache.kafka:kafka-clients:0.8.2.1'
+  compile 'org.apache.kafka:kafka_2.11:0.10.2.0'
+  compile 'org.apache.kafka:kafka-clients:0.10.2.0'
   compile 'org.apache.curator:curator-recipes:2.8.0'
   compile 'org.apache.curator:curator-test:2.8.0'
 


### PR DESCRIPTION
Hi @aleksdikanski 

Thanks for writing this plugin. It's very helpful. I was trying to setup my project with client libs for 0.10.2.0 and it wouldn't work.
Also 0.8 is kind of old. 

So I've upgraded Kafka to 0.10.2.0.

Thanks again!